### PR TITLE
improve mobile responsiveness across header, projects, experience, co…

### DIFF
--- a/src/sections/contact/Contact.ts
+++ b/src/sections/contact/Contact.ts
@@ -48,6 +48,14 @@ export default function contact() {
   email.innerHTML = `${textsContact[0]}`;
   contact.appendChild(email);
 
+  // Send Email button (mailto)
+  const emailButton = document.createElement('a');
+  emailButton.id = 'email-button';
+  emailButton.href = 'mailto:jhadengoy@gmail.com';
+  emailButton.textContent = 'Send Email';
+  emailButton.setAttribute('aria-label', 'Send an email to jhadengoy@gmail.com');
+  contact.appendChild(emailButton);
+
   // Socials
   const socials = document.createElement('div');
   socials.id = 'socials';

--- a/src/sections/header/Header.ts
+++ b/src/sections/header/Header.ts
@@ -646,6 +646,9 @@ function positionNavbar() {
     navigationBar.style.top = '';
     navigationBar.style.left = '';
     navigationBar.style.right = '';
+    navigationBar.style.bottom = '';
+    navigationBar.style.position = '';
+    navigationBar.style.transform = '';
     return;
   }
 

--- a/src/style/responsive.scss
+++ b/src/style/responsive.scss
@@ -1,3 +1,5 @@
+@import './variables.module.scss';
+
 /*
    Breakpoints:
    - Up to Tablet Landscape (and smaller desktops): <= 820px
@@ -34,9 +36,7 @@
   #scroll-prompt,
   #sound,
   #about,
-  #awards,
-  #this-website,
-  .award-certificate {
+  #this-website {
     display: none;
   }
 
@@ -80,24 +80,22 @@
   top: auto !important;
   left: auto !important;
   right: auto !important;
+  bottom: auto !important;
+  transform: none !important;
 
   display: flex !important;
   justify-content: center !important;
+  align-items: center !important;
 
-  width: 100% !important;        /* take full row */
-  max-width: 100% !important;
-  margin: 0.5vh 0 0 0 !important;
+  width: fit-content !important;
+  max-width: 95vw !important;
+  margin: 0.5vh auto 0 auto !important;
 
   flex-wrap: wrap;
   gap: 0.4rem;
-  padding: 0.25em 0.4em;
+  padding: 0.25em 0.6em;
   box-sizing: border-box;
   text-align: center;
-}
-
-#header-nav a {
-  font-size: clamp(0.85em, 2.5vw, 1em);
-  padding: 2px 5px;
 }
 
 #header-nav.scrolled {
@@ -105,16 +103,18 @@
   top: auto !important;
   left: auto !important;
   right: auto !important;
+  bottom: auto !important;
+  transform: none !important;
 
-  display: inline-flex !important;
+  display: flex !important;
   width: fit-content !important;
-  max-width: 90vw;
+  max-width: 95vw !important;
 
   margin: 0.5vh auto 0 auto !important;
 
   justify-content: center !important;
   flex-wrap: wrap;
-  padding: 0.25em 0.4em;
+  padding: 0.25em 0.6em;
   gap: 0.4rem;
 }
 
@@ -148,22 +148,125 @@
 
   /* Projects */
   #projects-container {
-    display: flex;
-    flex-direction: column;
+    display: grid !important;
+    grid-template-columns: repeat(2, 1fr) !important;
     background: none;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 10px;
+    padding: 10px;
   }
 
   .project-card {
-    padding: 20px;
-    max-width: 85vw;
+    padding: 12px;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .project-image {
+    height: auto;
+    width: 100%;
+    max-width: 100%;
+    aspect-ratio: 1 / 1;
+    object-fit: cover;
+    margin-bottom: 12px;
   }
 
   .project-title {
-    font-size: 1.4em;
-    max-width: 15ch;
-    white-space: unset;
+    font-size: 1.05em;
+    max-width: 100%;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
     text-shadow: none;
+    height: auto;
+    min-height: 0;
+    line-height: 1.15;
+    margin-bottom: 0.5em;
+    letter-spacing: 0.04em;
+  }
+
+  .project-summary {
+    font-size: 0.9em;
+    padding: 0.5em 0 0 0;
+    text-align: left;
+  }
+
+  .technologies,
+  .repo-link,
+  .separator {
+    font-size: 0.8em;
+  }
+
+  /* Experience (Awards section visible on mobile) */
+  #awards {
+    display: flex;
+    padding: 0 12px;
+  }
+
+  #awards-container {
+    width: 100%;
+  }
+
+  .award {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 10px;
+    margin-bottom: 3em;
+    width: 100%;
+  }
+
+  .award-certificate {
+    display: flex;
+    margin: 0;
+    padding: 8px 6px;
+    flex: 0 0 auto;
+    width: 80px;
+    height: 80px;
+    align-items: center;
+    justify-content: center;
+
+    img {
+      width: 100%;
+      height: 100%;
+      max-width: 64px;
+      max-height: 64px;
+      object-fit: contain;
+    }
+  }
+
+  .award-logo {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+
+  .award-details {
+    margin-top: 0;
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .award-title {
+    font-size: 1em;
+    width: auto;
+    line-height: 1.15;
+    display: inline-block;
+  }
+
+  .award-awarder {
+    font-size: 0.9em;
+    line-height: 1.15;
+  }
+
+  .award-title > span,
+  .award-awarder > span {
+    letter-spacing: 0.02em;
+  }
+
+  .award-description {
+    font-size: 0.8em;
+    margin-left: 0;
+    margin-top: 0.4em;
+    line-height: 1.25;
   }
 
   /* Contact */
@@ -172,11 +275,50 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 0 40px;
+    padding: 0 20px;
 
     p {
-      padding: 10px 40px;
+      padding: 10px 20px;
     }
+
+    a {
+      font-size: 1.4rem;
+    }
+  }
+
+  #email {
+    margin-bottom: 1.2em !important;
+  }
+
+  #email-button {
+    display: inline-block;
+    margin: 0.4em auto 1.4em auto;
+    padding: 0.7em 1.6em;
+    background-color: $black;
+    color: $white !important;
+    border: $border;
+    box-shadow: $shadow;
+    font-size: 1.05rem !important;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  #email-button:hover {
+    transform: scale(1.04);
+  }
+
+  #socials {
+    display: flex !important;
+    flex-direction: row !important;
+    justify-content: center;
+    align-items: center;
+    gap: 1.2em;
+  }
+
+  .social {
+    margin: 0;
   }
 
   #project-request-contact {
@@ -199,16 +341,6 @@
     top: 15vh;
     right: 5vw;
     font-size: 1.6em;
-  }
-
-  /* Award (Visible Styles for this breakpoint if needed) */
-  .award-title {
-    font-size: 1.4em;
-    width: 10ch;
-  }
-
-  .award-awarder {
-    font-size: 1.2em;
   }
 
   /* Ticker */
@@ -243,8 +375,8 @@
   }
 }
 
-/* Small to Medium Desktops (max-width: 1100px) */
-@media only screen and (max-width: 1100px) {
+/* Small to Medium Desktops (821px - 1100px) */
+@media only screen and (min-width: 821px) and (max-width: 1100px) {
   #socials {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
…ntact

- Center the mobile navbar with margin auto + width fit-content, and clear inline drag/position styles on resize so it stays centered.
- Fix project title overflow by removing the inherited 50px height and allowing wrapping inside the card.
- Switch the mobile project grid to 2 columns so the list is scannable.
- Show experience logos on mobile with a compact 80px tile and shrink the title/role/description so each entry fits in a row beside the logo.
- Add a Send Email mailto button in the contact section, and force the LinkedIn/GitHub icons to sit side by side on mobile.