### PR TITLE
tighten mobile layout: hero, intro, experience titles, projects footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" prefix="og: https://ogp.me/ns#">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <script type="module">
       const GA_TRACKING_ID = import.meta.env.VITE_GA_TRACKING_ID;
 

--- a/src/style/responsive.scss
+++ b/src/style/responsive.scss
@@ -15,13 +15,25 @@
 
 @media only screen and (max-width: 820px) {
   /* General Body and Main */
+  html,
   body {
-    max-width: fit-content;
+    width: 100vw;
+    max-width: 100vw;
+    overflow-x: hidden;
+    border-right: none !important;
+  }
+
+  main,
+  #main {
+    width: 100%;
+    max-width: 100vw;
     overflow-x: hidden;
   }
 
-  main {
+  #header {
     width: 100%;
+    max-width: 100vw;
+    overflow-x: hidden;
   }
 
   /* Elements to Hide */
@@ -53,10 +65,12 @@
 }
 
 #welcome {
-  top: 15vh;
-  left: 1vw;
+  top: 12vh;
+  left: 2vw;
   img {
-    width: 300px;
+    width: 38vw;
+    max-width: 180px;
+    height: auto;
   }
 }
 
@@ -65,13 +79,26 @@
   margin-top: 0.5vh;
   position: static;
   text-align: center;
-  font-size: clamp(20px, 10vw, 40px);
-  line-height: clamp(20px, 10vw, 40px);
+  white-space: normal;
+  word-break: break-word;
+  padding: 0 8px;
+  max-width: 100vw;
+  font-size: clamp(18px, 7.5vw, 34px);
+  line-height: 1.05;
 
   span {
     font-size: inherit;
     line-height: inherit;
   }
+}
+
+#name.scrolled {
+  font-size: clamp(14px, 4.5vw, 22px);
+  white-space: nowrap;
+  text-align: left;
+  max-width: 70vw;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* Navbar - Mobile responsive */
@@ -125,14 +152,36 @@
 
   /* Intro */
   #intro {
+    position: absolute;
+    top: 78vh;
+    left: 0;
+    right: 0;
+    min-width: 0;
+    width: 100vw;
+    max-width: 100vw;
+    padding: 0 12px;
+    box-sizing: border-box;
+    justify-content: center;
+    overflow: hidden;
+
     p {
-      font-size: 1.3em;
+      font-size: clamp(0.85rem, 3.2vw, 1.05rem);
+      max-width: 90vw;
+      min-width: 0;
+      margin: 0;
+      padding: 6px 8px;
+      line-height: 1.2;
+      text-align: center;
     }
   }
 
-  #right {
+  #intro #right {
     position: static;
-    column-count: 1;
+    column-count: 1 !important;
+    column-gap: 0 !important;
+    max-width: 90vw;
+    min-width: 0;
+    text-align: center;
   }
 
   #duck-placeholder {
@@ -196,6 +245,11 @@
     font-size: 0.8em;
   }
 
+  /* Hide the "list updated regularly" footer paragraph on mobile - it overflows */
+  #more {
+    display: none;
+  }
+
   /* Experience (Awards section visible on mobile) */
   #awards {
     display: flex;
@@ -246,20 +300,38 @@
   }
 
   .award-title {
-    font-size: 1em;
+    font-size: clamp(0.95rem, 4vw, 1.15rem);
     width: auto;
+    max-width: 100%;
     line-height: 1.15;
-    display: inline-block;
+    display: block;
+    overflow-wrap: break-word;
+    word-break: normal;
   }
 
   .award-awarder {
-    font-size: 0.9em;
+    font-size: clamp(0.8rem, 3.4vw, 1rem);
     line-height: 1.15;
+    display: block;
+    max-width: 100%;
+    overflow-wrap: break-word;
   }
 
+  /* Disable per-char inline-block layout on mobile so titles wrap by word, not by character */
   .award-title > span,
   .award-awarder > span {
-    letter-spacing: 0.02em;
+    display: inline;
+    white-space: normal;
+    letter-spacing: 0;
+  }
+
+  .award-title:hover > span,
+  .award-awarder:hover > span {
+    transform: none;
+  }
+
+  .award-awarder br {
+    display: none;
   }
 
   .award-description {
@@ -338,9 +410,10 @@
 
   #japanese {
     position: absolute;
-    top: 15vh;
-    right: 5vw;
-    font-size: 1.6em;
+    top: 12vh;
+    right: 3vw;
+    font-size: 0.9em;
+    padding: 0.2em 0.05em;
   }
 
   /* Ticker */


### PR DESCRIPTION
- Disable pinch-zoom via viewport meta (user-scalable=no)
- Body/main: width 100vw + overflow-x hidden, remove border-right that pushed content past viewport edge clipping the site name
- Name: white-space:normal so it wraps instead of clipping; smaller font cap
- Welcome image: 38vw (max 180px) so it doesn't dominate the hero
- Japanese box: 0.9em font, smaller padding
- Intro: fix column-count:1 with !important + higher specificity (#intro #right) so the base nested SCSS no longer wins and text stops leaking sideways
- Experience titles: override per-char spans to display:inline on mobile so words wrap at boundaries instead of mid-character; disable rotate hover
- Hide #more "list updated regularly" paragraph on mobile (white-space:nowrap caused overflow with no good fix)