### PR TITLE
add decorative draggable elements + restore project footer on mobile

### DIFF
--- a/src/style/responsive.scss
+++ b/src/style/responsive.scss
@@ -37,12 +37,7 @@
   }
 
   /* Elements to Hide */
-  #smiley,
-  #art,
-  #rays,
   #handwriting,
-  #box,
-  #new,
   #sunscreen,
   #left,
   #scroll-prompt,
@@ -50,6 +45,77 @@
   #about,
   #this-website {
     display: none;
+  }
+
+  /* Decorative draggable elements - sized + positioned for the mobile hero */
+  #smiley {
+    position: absolute;
+    left: 4vw;
+    bottom: 14vh;
+    z-index: 4;
+    /* Override the desktop moveSmiley keyframe (animates to bottom: 200px which is wrong on mobile) */
+    animation: levitate 2s ease-in-out infinite !important;
+
+    img {
+      width: 70px;
+    }
+  }
+
+  #rays {
+    top: 11vh;
+    left: 0;
+    width: 90px;
+    max-height: 90px;
+    border-radius: 90px;
+
+    img {
+      width: 90px;
+      border-radius: 90px;
+    }
+  }
+
+  #box {
+    position: absolute;
+    top: 22vh;
+    right: 4vw;
+    width: 90px;
+    height: 90px;
+    padding: 6px;
+
+    button {
+      top: 4px;
+      right: 4px;
+      height: 22px;
+      width: 24px;
+      font-size: 0.85rem;
+      line-height: 22px;
+    }
+  }
+
+  #art {
+    top: auto;
+    bottom: 16vh;
+    right: 4vw;
+    left: auto;
+    width: 75px;
+    height: 75px;
+
+    img {
+      width: 75px;
+      height: 75px;
+    }
+  }
+
+  #new {
+    position: absolute;
+    top: 36vh !important;
+    left: auto;
+    right: 6vw;
+    transform: rotateZ(-12deg);
+
+    img {
+      width: 80px;
+    }
   }
 
 /* Header */
@@ -239,15 +305,42 @@
     text-align: left;
   }
 
-  .technologies,
-  .repo-link,
-  .separator {
-    font-size: 0.8em;
+  /* Reveal made-with + repo link on mobile (no hover state on touch devices) */
+  .project-card .technologies,
+  .project-card .repo-link,
+  .project-card .separator {
+    opacity: 1 !important;
   }
 
-  /* Hide the "list updated regularly" footer paragraph on mobile - it overflows */
+  .technologies {
+    font-size: 0.65rem;
+    padding: 0.4em 0.6em;
+    margin: 0.2rem 0 0.8rem 0;
+    word-break: break-word;
+    white-space: normal;
+    line-height: 1.3;
+    align-self: flex-start;
+    max-width: 100%;
+  }
+
+  .separator {
+    font-size: 0.8em;
+    margin: 0.2em 0;
+  }
+
+  .repo-link {
+    font-size: 0.95rem;
+    word-break: break-word;
+  }
+
+  /* Restore the projects footer on mobile - allow it to wrap so it doesn't overflow */
   #more {
-    display: none;
+    display: block;
+    font-size: 0.95em;
+    padding: 14px 16px;
+    white-space: normal;
+    line-height: 1.25;
+    box-sizing: border-box;
   }
 
   /* Experience (Awards section visible on mobile) */


### PR DESCRIPTION
- Show smiley, rays (behind welcome), box, art, and new sticker on mobile with compact sizes/positions so the hero matches the desktop's playful composition instead of looking bare.
- Override moveSmiley animation on mobile (which keyframes to bottom:200px, pushing the face off-screen) by forcing levitate-only.
- Reveal .technologies and .repo-link on project cards at mobile width (no hover on touch devices) and shrink/wrap their text.
- Restore #more "list updated regularly" footer on mobile with white-space normal so it wraps cleanly and brings back the divider line between projects and experience.